### PR TITLE
Corrected image link bottom of page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16744,7 +16744,7 @@ In 2021, this infographic was awarded a Registered Graphic Designers, RGD In-Hou
 </defs>
 </svg>
 <div class="triumfLogo">
- <a href ="https://discoverourlab.triumf.ca" class="homebutton">
+ <a href ="https://www.triumf.ca/pif-nif" class="homebutton">
  <svg width="25vw" viewBox="0 0 297 38" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_901_2)">
 <path d="M52.26 8.62204H43.3186V3.36304H67.7463V8.62204H58.8049V31.8342H52.26V8.62204Z" fill="white"/>


### PR DESCRIPTION
Changed line 16747 "href=https://www.triumf.ca/pif-nif."

Have determined that downloading project changes behaviour to rocket animation which fails so have avoided committing this directly at the risk of overwriting main with this issue if present in check in.